### PR TITLE
Pass by ref is not effectively used inside body

### DIFF
--- a/src/DetachedFilterColumn.php
+++ b/src/DetachedFilterColumn.php
@@ -27,7 +27,7 @@ class DetachedFilterColumn implements JsonSerializable
         return [
             'width' => $this->width,
             'name' => $this->name,
-            'filters' => collect(is_callable($this->filters) ? $this->filters() : $this->filters)->map(function (&$filter) {
+            'filters' => collect(is_callable($this->filters) ? $this->filters() : $this->filters)->map(function ($filter) {
                 return $filter->jsonSerialize();
             }),
         ];

--- a/src/HasDetachedFilters.php
+++ b/src/HasDetachedFilters.php
@@ -64,7 +64,7 @@ trait HasDetachedFilters
 
     public static function modifyFilters(Collection $filters, bool $showInMenu)
     {
-        $filters->map(function (&$filter) use ($showInMenu) {
+        $filters->map(function ($filter) use ($showInMenu) {
             $filter->withMeta(['showInMenu' => $showInMenu]);
             $filter->class = $filter->key();
 

--- a/src/NovaDetachedFilters.php
+++ b/src/NovaDetachedFilters.php
@@ -112,7 +112,7 @@ class NovaDetachedFilters extends Card
 
     private function serializeFilters()
     {
-        return collect($this->getFilters())->map(function (&$filter) {
+        return collect($this->getFilters())->map(function ($filter) {
             return $filter->jsonSerialize();
         });
     }


### PR DESCRIPTION
And this fixed issue with PHP V8

```php
OptimistDigital\NovaDetachedFilters\NovaDetachedFilters::OptimistDigital\NovaDetachedFilters\{closure}(): Argument #1 ($filter) must be passed by reference, value given

```